### PR TITLE
Fix maven repo declaring in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ allprojects {
 
 Or in `settings.gradle.kts`:
 ```kotlin
-pluginManagement {
+dependencyResolutionManagement {
     repositories {
         ...
         mavenCentral()


### PR DESCRIPTION
It should be `dependencyResolutionManagement` instead of `pluginManagement` cause this lib is not a Gradle plugin.