### PR TITLE
Implement the ability to add a pinned footer to the LazyTable.

### DIFF
--- a/demo/src/commonMain/kotlin/eu/wewox/lazytable/screens/LazyTablePinnedScreen.kt
+++ b/demo/src/commonMain/kotlin/eu/wewox/lazytable/screens/LazyTablePinnedScreen.kt
@@ -134,7 +134,8 @@ private fun pinConfiguration(settings: Settings): LazyTablePinConfiguration =
             settings.pinName -> 1
             else -> 0
         },
-        rows = if (settings.showHeader) 1 else 0
+        rows = if (settings.showHeader) 1 else 0,
+        footer = settings.showFooter,
     )
 
 @Suppress("ComplexMethod")
@@ -240,6 +241,12 @@ private fun Settings(
     )
 
     SettingsRow(
+        text = "Show footer",
+        value = settings.showFooter,
+        onChange = { onChange(settings.copy(showFooter = it)) }
+    )
+
+    SettingsRow(
         text = "Pin name",
         value = settings.pinName,
         onChange = {
@@ -260,6 +267,7 @@ private fun Settings(
 
 private data class Settings(
     val showHeader: Boolean = true,
+    val showFooter: Boolean = true,
     val pinName: Boolean = false,
     val pinImage: Boolean = false,
 )

--- a/demo/src/commonMain/kotlin/eu/wewox/lazytable/screens/LazyTablePinnedScreen.kt
+++ b/demo/src/commonMain/kotlin/eu/wewox/lazytable/screens/LazyTablePinnedScreen.kt
@@ -267,7 +267,7 @@ private fun Settings(
 
 private data class Settings(
     val showHeader: Boolean = true,
-    val showFooter: Boolean = true,
+    val showFooter: Boolean = false,
     val pinName: Boolean = false,
     val pinImage: Boolean = false,
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.github.oleksandrbalan
 POM_ARTIFACT_ID=lazytable
-VERSION_NAME=1.6.0
+VERSION_NAME=1.7.0
 
 POM_NAME=Lazy Table
 POM_DESCRIPTION=Lazy layout for Jetpack Compose to display columns and rows of data on the two directional plane.

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.github.oleksandrbalan
 POM_ARTIFACT_ID=lazytable
-VERSION_NAME=1.7.0
+VERSION_NAME=1.6.0
 
 POM_NAME=Lazy Table
 POM_DESCRIPTION=Lazy layout for Jetpack Compose to display columns and rows of data on the two directional plane.

--- a/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTable.kt
+++ b/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTable.kt
@@ -59,14 +59,14 @@ public fun LazyTable(
             tableHeight.value = it.height.toFloat()
         },
     ) {
-        val newTableHeight = dimensionsPx.rowsSize.sum()
+        val minTableHeight = min(tableHeight.value, dimensionsPx.rowsSize.sum())
 
         scope.intervals.forEach { interval ->
             items(
                 count = interval.size,
                 layoutInfo = {
                     val info = interval.value.layoutInfo(it)
-                    info.toMinaBoxItem(pinConfiguration, dimensionsPx, min(tableHeight.value, newTableHeight))
+                    info.toMinaBoxItem(pinConfiguration, dimensionsPx, minTableHeight)
                 },
                 key = interval.value.key,
                 contentType = interval.value.contentType,
@@ -125,11 +125,9 @@ private fun LazyTableItem.getZIndex(pinConfiguration: LazyTablePinConfiguration)
 
     return if (pinnedColumn && pinnedRow) {
         ZIndexPinnedCorner
-    }
-    else if (pinnedColumn && pinnedFooter) {
-        ZIndexPinnedCorner
-    }
-    else if (pinnedColumn || pinnedRow || pinnedFooter) {
+    } else if (pinnedColumn && pinnedFooter) {
+        ZIndexPinnedFooter
+    } else if (pinnedColumn || pinnedRow || pinnedFooter) {
         ZIndexPinnedLine
     } else {
         ZIndexItem
@@ -161,6 +159,7 @@ public object LazyTableDefaults {
 private val DefaultColumnSize = 96.dp
 private val DefaultRowSize = 48.dp
 
+private const val ZIndexPinnedFooter = 3f
 private const val ZIndexPinnedCorner = 2f
 private const val ZIndexPinnedLine = 1f
 private const val ZIndexItem = 0f

--- a/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTable.kt
+++ b/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTable.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.zIndex
 import eu.wewox.minabox.MinaBox
 import eu.wewox.minabox.MinaBoxItem
 import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Lazy layout to display columns and rows of data on the two directional plane.
@@ -58,12 +59,14 @@ public fun LazyTable(
             tableHeight.value = it.height.toFloat()
         },
     ) {
+        val newTableHeight = dimensionsPx.rowsSize.sum()
+
         scope.intervals.forEach { interval ->
             items(
                 count = interval.size,
                 layoutInfo = {
                     val info = interval.value.layoutInfo(it)
-                    info.toMinaBoxItem(pinConfiguration, dimensionsPx, tableHeight.value)
+                    info.toMinaBoxItem(pinConfiguration, dimensionsPx, min(tableHeight.value, newTableHeight))
                 },
                 key = interval.value.key,
                 contentType = interval.value.contentType,

--- a/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTableItem.kt
+++ b/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTableItem.kt
@@ -22,13 +22,22 @@ public class LazyTableItem(
  */
 internal fun LazyTableItem.toMinaBoxItem(
     pinConfiguration: LazyTablePinConfiguration,
-    dimensions: LazyTablePxDimensions
+    dimensions: LazyTablePxDimensions,
+    tableHeight: Float,
 ): MinaBoxItem =
     MinaBoxItem(
         x = dimensions.sumOfColumns(0 until column),
-        y = dimensions.sumOfRows(0 until row),
+        y = if (pinConfiguration.footer && row == dimensions.rowsSize.size - 1) {
+            tableHeight - dimensions.rowsSize[dimensions.rowsSize.size - 1]
+        } else {
+            dimensions.sumOfRows(0 until row)
+        },
         width = dimensions.sumOfColumns(column until column + columnsCount),
         height = dimensions.sumOfRows(row until row + rowsCount),
         lockHorizontally = column < pinConfiguration.columns(row),
-        lockVertically = row < pinConfiguration.rows(column),
+        lockVertically = if (pinConfiguration.footer && row == dimensions.rowsSize.size - 1) {
+            true
+        } else {
+            row < pinConfiguration.rows(column)
+        },
     )

--- a/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTablePinConfiguration.kt
+++ b/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTablePinConfiguration.kt
@@ -1,36 +1,42 @@
 package eu.wewox.lazytable
 
 /**
- * The configuration of pinned columns and rows.
+ * The configuration of pinned columns, rows, and footer.
  * Columns and rows are pinned from the beginning, then they are always displayed when user scrolls
  * in lazy table.
  *
  * @property columns The count of pinned columns for given row.
  * @property rows The count of pinned rows for given column.
+ * @property footer The flag for showing a pinned footer.
  */
 public data class LazyTablePinConfiguration internal constructor(
     val columns: (row: Int) -> Int,
     val rows: (column: Int) -> Int,
+    val footer: Boolean,
 )
 
 /**
- * Creates configuration of pinned columns and rows.
+ * Creates configuration of pinned columns,rows, and footer.
  *
  * @param columns The count of pinned columns.
  * @param rows The count of pinned rows.
+ * @property footer The flag for showing a pinned footer.
  */
 public fun lazyTablePinConfiguration(
     columns: Int = 0,
     rows: Int = 0,
-): LazyTablePinConfiguration = LazyTablePinConfiguration({ columns }, { rows })
+    footer: Boolean = false,
+): LazyTablePinConfiguration = LazyTablePinConfiguration({ columns }, { rows }, footer)
 
 /**
- * Creates configuration of pinned columns and rows.
+ * Creates configuration of pinned columns, rows, and footer.
  *
  * @param columns The count of pinned columns for given row.
  * @param rows The count of pinned rows for given column.
+ * @property footer The flag for showing a pinned footer.
  */
 public fun lazyTablePinConfiguration(
     columns: (row: Int) -> Int = { 0 },
     rows: (column: Int) -> Int = { 0 },
-): LazyTablePinConfiguration = LazyTablePinConfiguration(columns, rows)
+    footer: Boolean = false
+): LazyTablePinConfiguration = LazyTablePinConfiguration(columns, rows, footer)

--- a/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTablePinConfiguration.kt
+++ b/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTablePinConfiguration.kt
@@ -20,7 +20,7 @@ public data class LazyTablePinConfiguration internal constructor(
  *
  * @param columns The count of pinned columns.
  * @param rows The count of pinned rows.
- * @property footer The flag for showing a pinned footer.
+ * @param footer The flag for showing a pinned footer.
  */
 public fun lazyTablePinConfiguration(
     columns: Int = 0,
@@ -33,7 +33,7 @@ public fun lazyTablePinConfiguration(
  *
  * @param columns The count of pinned columns for given row.
  * @param rows The count of pinned rows for given column.
- * @property footer The flag for showing a pinned footer.
+ * @param footer The flag for showing a pinned footer.
  */
 public fun lazyTablePinConfiguration(
     columns: (row: Int) -> Int = { 0 },


### PR DESCRIPTION
Closes #17 

Description:
Implemented the ability to add a pinned footer row to a LazyTable. Updated the configuration to allow consumers to set a footer flag indicating to pin a footer row. We also updated the MinaBox call within the LazyTable to pass the table height to the `toMineBoxItem` extension function and added an extra item to push the second to last row up when accounting for a pinned footer row. Within the `toMineBoxItem` extension function we accounted for adjusting the `y` coordinate and how `lockVertically` is set.

Evidence of changes:
- Do note, I wasn't able to run the iOS app successfully as I was getting coroutine exception thrown.


https://github.com/oleksandrbalan/lazytable/assets/9346240/93433483-46c5-4fad-b53d-3779691dd1da



<img width="936" alt="desktop_lazytable1" src="https://github.com/oleksandrbalan/lazytable/assets/9346240/9da697b6-92b3-4043-b18e-5c603d3e8c9c">
<img width="936" alt="desktop_lazytable2" src="https://github.com/oleksandrbalan/lazytable/assets/9346240/9721ef14-2835-4f21-8fa8-bff27dbc2e1d">
<img width="936" alt="desktop_lazytable3" src="https://github.com/oleksandrbalan/lazytable/assets/9346240/7d8af3d6-530a-4351-b9d9-6b6b58106261">
