### PR TITLE
Improve LazyTable state remembering

### DIFF
--- a/demo/src/commonMain/kotlin/eu/wewox/lazytable/screens/LazyTableStateScreen.kt
+++ b/demo/src/commonMain/kotlin/eu/wewox/lazytable/screens/LazyTableStateScreen.kt
@@ -19,7 +19,7 @@ import eu.wewox.lazytable.Example
 import eu.wewox.lazytable.LazyTable
 import eu.wewox.lazytable.LazyTableItem
 import eu.wewox.lazytable.data.createCells
-import eu.wewox.lazytable.rememberLazyTableState
+import eu.wewox.lazytable.rememberSaveableLazyTableState
 import eu.wewox.lazytable.ui.components.TopBar
 import kotlinx.coroutines.launch
 
@@ -43,7 +43,7 @@ fun LazyTableStateScreen(
         val cells = remember { createCells(columns, rows) }
 
         val scope = rememberCoroutineScope()
-        val state = rememberLazyTableState()
+        val state = rememberSaveableLazyTableState()
 
         LazyTable(
             state = state,

--- a/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTable.kt
+++ b/lazytable/src/commonMain/kotlin/eu/wewox/lazytable/LazyTable.kt
@@ -34,7 +34,7 @@ import kotlin.math.min
 @Composable
 public fun LazyTable(
     modifier: Modifier = Modifier,
-    state: LazyTableState = rememberLazyTableState(),
+    state: LazyTableState = rememberSaveableLazyTableState(),
     pinConfiguration: LazyTablePinConfiguration = LazyTableDefaults.pinConfiguration(),
     dimensions: LazyTableDimensions = LazyTableDefaults.dimensions(),
     contentPadding: PaddingValues = PaddingValues(0.dp),


### PR DESCRIPTION
- Replace `rememberLazyTableState` with `rememberSaveableLazyTableState` to ensure state persistence across configuration changes and deprecate `rememberLazyTableState`.
- Update `LazyTable` composable to use `rememberSaveableLazyTableState` by default.
- Add a `Saver` implementation to the `LazyTableState` for proper state restoration.